### PR TITLE
Rewrite mergeSortedArrays for clarity

### DIFF
--- a/src/array/__tests__/getLast-test.js
+++ b/src/array/__tests__/getLast-test.js
@@ -1,24 +1,25 @@
 import { expect } from 'chai';
-import getLastTick from '../getLastTick';
+import getLast from '../getLast';
 
-describe('getLastTick', () => {
+describe('getLast', () => {
     it('when no input, result is undefined', () => {
-        const lastTick = getLastTick();
+        const lastTick = getLast();
         expect(lastTick).to.be.undefined;
     });
 
     it('when no elements in the array, result is undefined', () => {
-        const lastTick = getLastTick([]);
+        const lastTick = getLast([]);
         expect(lastTick).to.be.undefined;
     });
 
     it('returns last item in array', () => {
-        const wuut = getLastTick([1]);
+        const wuut = getLast([1]);
         expect(wuut).to.equal(1);
     });
 
     it('returns last item in array, even if it is object', () => {
-        const wuut = getLastTick([{ quote: 5 }]);
+        const wuut = getLast([{ quote: 5 }]);
         expect(wuut).to.deep.equal({ quote: 5 });
     });
 });
+

--- a/src/array/getLast.js
+++ b/src/array/getLast.js
@@ -1,0 +1,2 @@
+export default (arr: any[]): ?any =>
+    arr && (arr.length === 0 ? undefined : arr[arr.length - 1]);

--- a/src/array/mergeSortedArrays.js
+++ b/src/array/mergeSortedArrays.js
@@ -3,7 +3,6 @@ type Getter = (x: any) => any;
 export default (arr1: any[], arr2: any[],
                 getter1: Getter = x => x, getter2: Getter = x => x,
                 deduplication: Boolean = true) => {
-
     /**
      * compare element using getter
      * @param a
@@ -17,10 +16,6 @@ export default (arr1: any[], arr2: any[],
         const valA = getter1(a);
         const valB = getter2(b);
 
-        if (valA === valB) {
-            return 0;
-        }
-
         if (valA > valB) {
             return 1;
         }
@@ -28,6 +23,8 @@ export default (arr1: any[], arr2: any[],
         if (valA < valB) {
             return -1;
         }
+
+        return 0;
     };
 
     // clone so that does not change arguments
@@ -52,7 +49,7 @@ export default (arr1: any[], arr2: any[],
         }
 
         const last = result.length > 0 && result[result.length - 1];
-        let toAdd = undefined;
+        let toAdd;
         switch (compare(a1Head, a2Head)) {
             case 0: {
                 if (deduplication) a2Clone.shift();
@@ -69,6 +66,7 @@ export default (arr1: any[], arr2: any[],
                 toAdd = a1Clone.shift();
                 break;
             }
+            default:                // impossible
         }
 
         // if dedup is true, do not append same element

--- a/src/array/mergeSortedArrays.js
+++ b/src/array/mergeSortedArrays.js
@@ -2,7 +2,7 @@ type Getter = (x: any) => any;
 
 export default (arr1: any[], arr2: any[],
                 getter1: Getter = x => x, getter2: Getter = x => x,
-                deduplication: Boolean = true) => {
+                deduplication: boolean = true) => {
     /**
      * compare element using getter
      * @param a

--- a/src/array/mergeSortedArrays.js
+++ b/src/array/mergeSortedArrays.js
@@ -1,26 +1,82 @@
 type Getter = (x: any) => any;
 
-const getVal = (getter = x => x, arr: any[], i: number) =>
-    arr[i] ? getter(arr[i]) : Number.MAX_VALUE;
+export default (arr1: any[], arr2: any[],
+                getter1: Getter = x => x, getter2: Getter = x => x,
+                deduplication: Boolean = true) => {
 
-export default (arr1: any[], arr2: any[], getter1: Getter, getter2: Getter) => {
-    let i1 = 0;
-    let i2 = 0;
-    const result = [];
-    while (i1 < arr1.length || i2 < arr2.length) {
-        const val1 = getVal(getter1, arr1, i1);
-        const val2 = getVal(getter2, arr2, i2);
-        if (val1 < val2) {
-            result.push(arr1[i1]);
-            i1++;
-        } else if (val1 > val2) {
-            result.push(arr2[i2]);
-            i2++;
-        } else {
-            result.push(arr1[i1]);
-            i1++;
-            i2++;
+    /**
+     * compare element using getter
+     * @param a
+     * @param b
+     * @returns {number}
+     *   0  -> equal
+     *   1  -> `a` bigger than `b`
+     *   -1 -> `b` bigger than `a`
+     */
+    const compare = (a, b) => {
+        const valA = getter1(a);
+        const valB = getter2(b);
+
+        if (valA === valB) {
+            return 0;
         }
+
+        if (valA > valB) {
+            return 1;
+        }
+
+        if (valA < valB) {
+            return -1;
+        }
+    };
+
+    // clone so that does not change arguments
+    const a1Clone = arr1.slice(0);
+    const a2Clone = arr2.slice(0);
+
+    let result = [];
+
+    // loop until both array is empty
+    while (a1Clone.length > 0 || a2Clone.length > 0) {
+        const a1Head = a1Clone[0];
+        const a2Head = a2Clone[0];
+
+        if (!a1Head) {
+            result = result.concat(a2Clone);
+            break;                      // break if one of the array is empty
+        }
+
+        if (!a2Head) {
+            result = result.concat(a1Clone);
+            break;                      // break if one of the array is empty
+        }
+
+        const last = result.length > 0 && result[result.length - 1];
+        let toAdd = undefined;
+        switch (compare(a1Head, a2Head)) {
+            case 0: {
+                if (deduplication) a2Clone.shift();
+                toAdd = a1Clone.shift();
+                break;
+            }
+            // a2Head is smaller
+            case 1: {
+                toAdd = a2Clone.shift();
+                break;
+            }
+            // a1Head is smaller
+            case -1: {
+                toAdd = a1Clone.shift();
+                break;
+            }
+        }
+
+        // if dedup is true, do not append same element
+        if (deduplication && last && getter1(last) === getter2(toAdd)) {
+            break;
+        }
+        result.push(toAdd);
     }
+
     return result;
 };

--- a/src/index.js
+++ b/src/index.js
@@ -87,7 +87,6 @@ export { default as doCandlesDifferJustOneEntry } from './ticks/doCandlesDifferJ
 export { default as doTicksDifferJustOneEntry } from './ticks/doTicksDifferJustOneEntry';
 export { default as doTicksEqual } from './ticks/doTicksEqual';
 export { default as getLastOHLCTick } from './ticks/getLastOHLCTick';
-export { default as getLastTick } from './ticks/getLastTick';
 export { default as getLastTickQuote } from './ticks/getLastTickQuote';
 export { default as historyToTicks } from './ticks/historyToTicks';
 export { default as ohlcToData } from './ticks/ohlcToData';

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ export { default as arrayEqual } from './array/arrayEqual';
 export { default as arrayMax } from './array/arrayMax';
 export { default as arrayMin } from './array/arrayMin';
 export { default as arrayToObject } from './array/arrayToObject';
+export { default as getLast } from './array/getLast';
 export { default as mergeSortedArrays } from './array/mergeSortedArrays';
 export { default as sequence } from './array/sequence';
 

--- a/src/ticks/getLastTick.js
+++ b/src/ticks/getLastTick.js
@@ -1,2 +1,0 @@
-export default (ticks: Tick[]): ?Tick =>
-    ticks && (ticks.length === 0 ? undefined : ticks[ticks.length - 1]);


### PR DESCRIPTION
I thought this would be clearer, and this handle duplication properly in case where the `alreadyMerged` contains same element with element to add.

test passed, but would still like anyone to have a closer look, to ensure I dont make things harder to read
